### PR TITLE
add zappi unlock command

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,6 @@
+#myenergi
+.myenergi.cfg
+
 # Byte-compiled / optimized / DLL files
 __pycache__/
 *.py[cod]

--- a/pymyenergi/cli.py
+++ b/pymyenergi/cli.py
@@ -177,6 +177,7 @@ def cli():
             "smart-boost",
             "mingreen",
             "priority",
+            "unlock",
         ],
     )
     subparser_zappi.add_argument("arg", nargs="*")

--- a/pymyenergi/zappi.py
+++ b/pymyenergi/zappi.py
@@ -346,3 +346,8 @@ class Zappi(BaseDevice):
             f"/cgi-zappi-mode-Z{self._serialno}-0-11-{int(amount)}-{time}"
         )
         return True
+    
+    async def unlock(self):
+        """Unlock"""
+        await self._connection.get(f"/cgi-jlock-Z{self._serialno}-00000010")
+        return True


### PR DESCRIPTION
Hi,

I was wondering if the zappi unlock command could be included in your excellent implementation?

I've added it to zappi.py, but sadly failed to test it on my home assistant installation.

Many thanks for your hard work.

Richard
