### PR TITLE
Fixed Zappi unlock API URL

### DIFF
--- a/pymyenergi/zappi.py
+++ b/pymyenergi/zappi.py
@@ -362,5 +362,5 @@ class Zappi(BaseDevice):
 
     async def unlock(self):
         """Unlock"""
-        await self._connection.get(f"/cgi-jlock-Z{self._serialno}-00000010")
+        await self._connection.get(f"/cgi-jlock-{self._serialno}-00000010")
         return True


### PR DESCRIPTION
The Zappi unlock API URL in the code is wrong. The [Z is not needed](https://github.com/twonk/MyEnergi-App-Api).
I tested my change, unlocking doesn't work with the Z but it works with it. 