### PR TITLE
Fix daily energy totals showing as zero

### DIFF
--- a/pymyenergi/base_device.py
+++ b/pymyenergi/base_device.py
@@ -63,6 +63,7 @@ class BaseDevice(ABC):
         self._serialno = serialno
         self._data = data or {}
         self._name = None
+        self.is_vhub_enabled = self._data.get("isVHubEnabled", False)
         self.ct_groups = {}
         self.refresh_ct_groups()
 

--- a/pymyenergi/client.py
+++ b/pymyenergi/client.py
@@ -77,7 +77,7 @@ class MyenergiClient:
             self._history_totals[key] = 0
         zappi_or_eddi_or_libbi = None
         for device in devices:
-            if device.kind == ZAPPI or device.kind == EDDI or device == LIBBI:
+            if device.is_vhub_enabled:
                 zappi_or_eddi_or_libbi = device
                 break
         if zappi_or_eddi_or_libbi is not None:


### PR DESCRIPTION
My daily totals stopped appearing in Home Assistant on the 19th June (generated today, green energy today, grid export today, grid import today). This was the date that MyEnergi had problems and the API went down so I assume the change is related to that.

I found the problem was pymyenergi was calculating totals using my Eddi rather than Zappi device as the Eddi was first in the API response. Instead of calculating from the first device, I have assumed that 'isVHubEnabled' signifies the correct device to use for totals. This works for me but only tested on my account.